### PR TITLE
allowing passing style props to set content style

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -14,6 +14,7 @@ export default function styleConstructor(theme = {}, calendarHeight) {
     contentStyle: {
       backgroundColor: '#ffff',
       height: calendarHeight + 10,
+      ...theme.contentStyle,
     },
     header: {
       paddingHorizontal: 30,


### PR DESCRIPTION
#### Problem
Passing `backgroundColor` in `container` in `styles` doesn't actually change the background color of EventCalendar. (It changes the background color when you scroll to either end of the day.)

```
<EventCalendar
  styles={{
    container: {
      backgroundColor: 'blue',
    },
  }}
/>
```
![image](https://user-images.githubusercontent.com/4150198/44376436-7c821f00-a4ad-11e8-92cb-8df569ffc24f.png)

#### Solution
Expose `contentStyle`.
```
<EventCalendar
  styles={{
    contentStyle: {
      backgroundColor: 'blue',
    },
  }}
/>
```
![image](https://user-images.githubusercontent.com/4150198/44376483-a6d3dc80-a4ad-11e8-935c-64ca41811b94.png)
