### PR TITLE
header should slide with the Day View when you swipe

### DIFF
--- a/src/EventCalendar.js
+++ b/src/EventCalendar.js
@@ -73,24 +73,61 @@ export default class EventCalendar extends React.Component {
       scrollToFirst = true,
       start = 0,
       end = 24,
+      formatHeader,
+      upperCaseHeader = false,
     } = this.props;
     const date = moment(initDate).add(index - this.props.size, 'days');
+
+    const leftIcon = this.props.headerIconLeft ? (
+        this.props.headerIconLeft
+    ) : (
+        <Image source={require('./back.png')} style={this.styles.arrow} />
+    );
+    const rightIcon = this.props.headerIconRight ? (
+        this.props.headerIconRight
+    ) : (
+        <Image source={require('./forward.png')} style={this.styles.arrow} />
+    );
+
+    let headerText = upperCaseHeader
+        ? date.format(formatHeader || 'DD MMMM YYYY').toUpperCase()
+        : date.format(formatHeader || 'DD MMMM YYYY');
+
     return (
-      <DayView
-        date={date}
-        index={index}
-        format24h={format24h}
-        formatHeader={this.props.formatHeader}
-        headerStyle={this.props.headerStyle}
-        renderEvent={this.props.renderEvent}
-        eventTapped={this.props.eventTapped}
-        events={item}
-        width={width}
-        styles={this.styles}
-        scrollToFirst={scrollToFirst}
-        start={start}
-        end={end}
-      />
+      <View style={[this.styles.container, { width }]}>
+        <View style={this.styles.header}>
+          <TouchableOpacity
+              style={this.styles.arrowButton}
+              onPress={this._previous}
+          >
+            {leftIcon}
+          </TouchableOpacity>
+          <View style={this.styles.headerTextContainer}>
+            <Text style={this.styles.headerText}>{headerText}</Text>
+          </View>
+          <TouchableOpacity
+              style={this.styles.arrowButton}
+              onPress={this._next}
+          >
+            {rightIcon}
+          </TouchableOpacity>
+        </View>
+        <DayView
+          date={date}
+          index={index}
+          format24h={format24h}
+          formatHeader={this.props.formatHeader}
+          headerStyle={this.props.headerStyle}
+          renderEvent={this.props.renderEvent}
+          eventTapped={this.props.eventTapped}
+          events={item}
+          width={width}
+          styles={this.styles}
+          scrollToFirst={scrollToFirst}
+          start={start}
+          end={end}
+        />
+      </View>
     );
   }
 
@@ -143,44 +180,10 @@ export default class EventCalendar extends React.Component {
       virtualizedListProps,
       events,
       initDate,
-      formatHeader,
-      upperCaseHeader = false,
     } = this.props;
-
-    const leftIcon = this.props.headerIconLeft ? (
-      this.props.headerIconLeft
-    ) : (
-      <Image source={require('./back.png')} style={this.styles.arrow} />
-    );
-    const rightIcon = this.props.headerIconRight ? (
-      this.props.headerIconRight
-    ) : (
-      <Image source={require('./forward.png')} style={this.styles.arrow} />
-    );
-
-    let headerText = upperCaseHeader
-      ? this.state.date.format(formatHeader || 'DD MMMM YYYY').toUpperCase()
-      : this.state.date.format(formatHeader || 'DD MMMM YYYY');
 
     return (
       <View style={[this.styles.container, { width }]}>
-        <View style={this.styles.header}>
-          <TouchableOpacity
-            style={this.styles.arrowButton}
-            onPress={this._previous}
-          >
-            {leftIcon}
-          </TouchableOpacity>
-          <View style={this.styles.headerTextContainer}>
-            <Text style={this.styles.headerText}>{headerText}</Text>
-          </View>
-          <TouchableOpacity
-            style={this.styles.arrowButton}
-            onPress={this._next}
-          >
-            {rightIcon}
-          </TouchableOpacity>
-        </View>
         <VirtualizedList
           ref="calendar"
           windowSize={2}


### PR DESCRIPTION
There is a perceived delay in the header date updating after swiping to the next/previous day view. This change incorporates the header within the Day View, providing a better user experience.