### PR TITLE
Add event click to hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ const events = [
 render () {
   return (
     <EventCalendar
+      hourTapped={this._hourTapped.bind(this)}
       eventTapped={this._eventTapped.bind(this)}
       events={this.state.events}
       width={width}

--- a/example/App.js
+++ b/example/App.js
@@ -103,11 +103,16 @@ export default class App extends React.Component {
     alert(JSON.stringify(event));
   }
 
+  _hourTapped(dateAndTime) {
+    alert(JSON.stringify(dateAndTime)); // dateAndTime is an object Moment()
+  }
+
   render() {
     return (
       <View style={{ flex: 1, marginTop: 20 }}>
         <EventCalendar
           eventTapped={this._eventTapped.bind(this)}
+          hourTapped={this._hourTapped.bind(this)}
           events={this.state.events}
           width={width}
           initDate={'2017-09-07'}

--- a/src/DayView.js
+++ b/src/DayView.js
@@ -104,18 +104,23 @@ export default class DayView extends React.PureComponent {
           {timeText}
         </Text>,
         i === start ? null : (
-          <View
+          <TouchableOpacity 
+            activeOpacity={0.5}
             key={`line${i}`}
-            style={[styles.line, { top: offset * index, width: width - 20 }]}
-          />
+            onPress={() => this._onHourTapped() }
+            style={[styles.line, { top: offset * index, width: width - 20, height: offset / 2}]}
+          >
+            <View />
+          </TouchableOpacity>
         ),
-        <View
+        <TouchableOpacity
+          activeOpacity={0.5}
           key={`lineHalf${i}`}
-          style={[
-            styles.line,
-            { top: offset * (index + 0.5), width: width - 20 },
-          ]}
-        />,
+          onPress={() => this._onHourTapped() }
+          style={[ styles.line, { top: offset * (index + 0.5), width: width - 20, height: offset / 2 } ]}
+        >
+          <View />
+        </TouchableOpacity>
       ];
     });
   }
@@ -132,6 +137,13 @@ export default class DayView extends React.PureComponent {
 
   _onEventTapped(event) {
     this.props.eventTapped(event);
+  }
+
+  _onHourTapped() {
+    if (this.props.hourTappped === null) {
+      return;
+    }
+    this.props.hourTappped(this.props.date);
   }
 
   _renderEvents() {

--- a/src/EventCalendar.js
+++ b/src/EventCalendar.js
@@ -120,6 +120,7 @@ export default class EventCalendar extends React.Component {
           headerStyle={this.props.headerStyle}
           renderEvent={this.props.renderEvent}
           eventTapped={this.props.eventTapped}
+          hourTappped={this.props.hourTappped}
           events={item}
           width={width}
           styles={this.styles}


### PR DESCRIPTION
Hey guys, I used your lib on my personal project and I needed to add an event click to add more events. I would like to share the idea with you. If you like you can merge it.

On my app I have one more function to avoid clicks on weekends or others week days that was passed to the Component. If this is merged i can make another pull request to add it too.

- Motivation
Would be good if we have and event to retrieve date and time without
events just in case we need or want to create an event using that empty
space.

- Solution
Add a function `hourTapped` that will receive our date and time
selected, with this date and time selected we can add a new event.
In `DayView` was changed the current `View` to a `TouchableOpacity` with
a `View` inside to mark space.